### PR TITLE
Remove usage of `Addr` in contract messages.

### DIFF
--- a/src/integration_test.rs
+++ b/src/integration_test.rs
@@ -609,7 +609,7 @@ fn swap_tokens_happy_path() {
     let swap_msg = ExecuteMsg::SwapAndSendTo {
         input_token: TokenSelect::Token1,
         input_amount: Uint128::new(10),
-        recipient: owner.clone(),
+        recipient: owner.to_string(),
         min_token: Uint128::new(3),
         expiration: None,
     };
@@ -926,7 +926,7 @@ fn token_to_token_swap() {
         .unwrap();
 
     let swap_msg = ExecuteMsg::PassThroughSwap {
-        output_amm_address: amm2.clone(),
+        output_amm_address: amm2.to_string(),
         input_token: TokenSelect::Token2,
         input_token_amount: Uint128::new(10),
         output_min_token: Uint128::new(8),
@@ -960,7 +960,7 @@ fn token_to_token_swap() {
         .unwrap();
 
     let swap_msg = ExecuteMsg::PassThroughSwap {
-        output_amm_address: amm1.clone(),
+        output_amm_address: amm1.to_string(),
         input_token: TokenSelect::Token2,
         input_token_amount: Uint128::new(10),
         output_min_token: Uint128::new(1),

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Addr, Uint128};
+use cosmwasm_std::Uint128;
 
 use cw20::{Denom, Expiration};
 
@@ -41,7 +41,7 @@ pub enum ExecuteMsg {
     },
     /// Chained swap converting A -> B and B -> C by leveraging two swap contracts
     PassThroughSwap {
-        output_amm_address: Addr,
+        output_amm_address: String,
         input_token: TokenSelect,
         input_token_amount: Uint128,
         output_min_token: Uint128,
@@ -50,7 +50,7 @@ pub enum ExecuteMsg {
     SwapAndSendTo {
         input_token: TokenSelect,
         input_amount: Uint128,
-        recipient: Addr,
+        recipient: String,
         min_token: Uint128,
         expiration: Option<Expiration>,
     },


### PR DESCRIPTION
Before this change a pass through swap with an invalid contract
is allowed and a swap message with an invalid receiver would not
fail until submessage execution. Both incorrect invocations would
result in an error for native transfers and a cw20 coin which
validated its addresses.