### PR TITLE
add owner to migration message

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1002,6 +1002,12 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractE
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
+    let owner = match msg.owner {
+        None => None,
+        Some(o) => Some(deps.api.addr_validate(&o)?)
+    };
+    OWNER.save(deps.storage, &owner)?;
+
     let protocol_fee_recipient = deps.api.addr_validate(&msg.protocol_fee_recipient)?;
     let total_fee_percent = msg.lp_fee_percent + msg.protocol_fee_percent;
     let max_fee_percent = Decimal::from_str(MAX_FEE_PERCENT)?;
@@ -1018,6 +1024,7 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, Co
         protocol_fee_recipient,
     };
     FEES.save(deps.storage, &fees)?;
+
     Ok(Response::default())
 }
 

--- a/src/integration_test.rs
+++ b/src/integration_test.rs
@@ -537,6 +537,7 @@ fn migrate() {
     assert_eq!(info.protocol_fee_recipient, owner.to_string());
 
     let migrate_msg = MigrateMsg {
+        owner: Some(owner.to_string()),
         lp_fee_percent,
         protocol_fee_percent,
         protocol_fee_recipient: owner.to_string(),
@@ -557,6 +558,7 @@ fn migrate() {
     assert_eq!(info.protocol_fee_percent, protocol_fee_percent);
     assert_eq!(info.lp_fee_percent, lp_fee_percent);
     assert_eq!(info.protocol_fee_recipient, owner.to_string());
+    assert_eq!(info.owner, Some(owner.to_string()));
 }
 
 #[test]

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -85,6 +85,7 @@ pub enum QueryMsg {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct MigrateMsg {
+    pub owner: Option<String>,
     pub protocol_fee_recipient: String,
     pub protocol_fee_percent: Decimal,
     pub lp_fee_percent: Decimal,


### PR DESCRIPTION
The current implementation of the migration does not allow the migrator to specify an owner for the contract. The means the fee configurations are immutable. This PR allows an optional owner to be supplied during migration. 