### PR TITLE
create separate query for fee info

### DIFF
--- a/src/msg.rs
+++ b/src/msg.rs
@@ -81,8 +81,8 @@ pub enum QueryMsg {
     Token2ForToken1Price {
         token2_amount: Uint128,
     },
+    Fee {},
 }
-
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct MigrateMsg {
     pub owner: Option<String>,
@@ -99,6 +99,10 @@ pub struct InfoResponse {
     pub token2_denom: Denom,
     pub lp_token_supply: Uint128,
     pub lp_token_address: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct FeeResponse {
     pub owner: Option<String>,
     pub lp_fee_percent: Decimal,
     pub protocol_fee_percent: Decimal,


### PR DESCRIPTION
This change is in reponse to a bug in pass through swaps where the originating contract is v1.1.1-beta and the terminating contract is v1.0.0-beta. This bug arises due to a unforseen interaction between #62 and #79. #62 extended the `info` query response and #79 used the info response to determine the position of the output token. This causes the pass through swap to throw an error as the older contract version does not return all the fields expected. 

This change resolved the error by keeping the `info` response consistent across versions and creating a new `fee` query for the fee split information.